### PR TITLE
fix: Update checksums for new Slack version

### DIFF
--- a/suites/bionic.toml
+++ b/suites/bionic.toml
@@ -29,7 +29,7 @@ version = "4.25.0"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
-    checksum = "aa2ce20f6f724e28ee8b9ceed555902f4ce822ea1bce01bc600706caf3add70a"
+    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]
 name = "spotify-client"

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -29,7 +29,7 @@ version = "4.25.0"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
-    checksum = "aa2ce20f6f724e28ee8b9ceed555902f4ce822ea1bce01bc600706caf3add70a"
+    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]
 name = "google-chrome-stable"

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -28,7 +28,7 @@ version = "4.25.0"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
-    checksum = "aa2ce20f6f724e28ee8b9ceed555902f4ce822ea1bce01bc600706caf3add70a"
+    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]
 name = "google-chrome-stable"

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -28,7 +28,7 @@ version = "4.25.0"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
-    checksum = "aa2ce20f6f724e28ee8b9ceed555902f4ce822ea1bce01bc600706caf3add70a"
+    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]
 name = "google-chrome-stable"

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -28,7 +28,7 @@ version = "4.25.0"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
-    checksum = "aa2ce20f6f724e28ee8b9ceed555902f4ce822ea1bce01bc600706caf3add70a"
+    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]
 name = "google-chrome-stable"


### PR DESCRIPTION
Should have been done as part of https://github.com/pop-os/repo-proprietary/pull/40.