### PR TITLE
Update Slack download URL

### DIFF
--- a/suites/bionic.toml
+++ b/suites/bionic.toml
@@ -28,7 +28,7 @@ name = "slack-desktop"
 version = "4.25.0"
 
     [[direct.urls]]
-    url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
+    url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
     checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -28,7 +28,7 @@ name = "slack-desktop"
 version = "4.25.0"
 
     [[direct.urls]]
-    url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
+    url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
     checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -27,7 +27,7 @@ name = "slack-desktop"
 version = "4.25.0"
 
     [[direct.urls]]
-    url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
+    url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
     checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -27,7 +27,7 @@ name = "slack-desktop"
 version = "4.25.0"
 
     [[direct.urls]]
-    url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
+    url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
     checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -27,7 +27,7 @@ name = "slack-desktop"
 version = "4.25.0"
 
     [[direct.urls]]
-    url = "https://downloads.slack-edge.com/linux_releases/${name}-${version}-amd64.deb"
+    url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
     checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
 
 [[direct]]


### PR DESCRIPTION
The old URL now returns an Access Denied message when testing in a web browser, which I assume is why the repo is currently failing to build. (I confirmed the sha256 checksum added in https://github.com/pop-os/repo-proprietary/pull/41 is correct.) The new URL downloads successfully from a web browser.