### PR TITLE
Update discord to 0.0.20

### DIFF
--- a/suites/bionic.toml
+++ b/suites/bionic.toml
@@ -16,11 +16,11 @@ version = "1.60.1-1631294805"
 
 [[direct]]
 name = "discord"
-version = "0.0.19"
+version = "0.0.20"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "65c4d4e75af540baf26568033c6a478e0f9e2d6dd46b8a5b539adf9b97a78aa2"
+    checksum = "d6045b5fe13d54b89ced04eb81fcd79ed7523842b82dd7143e964b13bb79d70c"
     arch = "amd64"
 
 [[direct]]

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -16,11 +16,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.19"
+version = "0.0.20"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "65c4d4e75af540baf26568033c6a478e0f9e2d6dd46b8a5b539adf9b97a78aa2"
+    checksum = "d6045b5fe13d54b89ced04eb81fcd79ed7523842b82dd7143e964b13bb79d70c"
     arch = "amd64"
 
 [[direct]]

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -15,11 +15,11 @@ version = "1.60.1-1631294805"
 
 [[direct]]
 name = "discord"
-version = "0.0.19"
+version = "0.0.20"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "65c4d4e75af540baf26568033c6a478e0f9e2d6dd46b8a5b539adf9b97a78aa2"
+    checksum = "d6045b5fe13d54b89ced04eb81fcd79ed7523842b82dd7143e964b13bb79d70c"
     arch = "amd64"
 
 [[direct]]

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.19"
+version = "0.0.20"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "65c4d4e75af540baf26568033c6a478e0f9e2d6dd46b8a5b539adf9b97a78aa2"
+    checksum = "d6045b5fe13d54b89ced04eb81fcd79ed7523842b82dd7143e964b13bb79d70c"
     arch = "amd64"
 
 [[direct]]

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.19"
+version = "0.0.20"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "65c4d4e75af540baf26568033c6a478e0f9e2d6dd46b8a5b539adf9b97a78aa2"
+    checksum = "d6045b5fe13d54b89ced04eb81fcd79ed7523842b82dd7143e964b13bb79d70c"
     arch = "amd64"
 
 [[direct]]


### PR DESCRIPTION
100% done using the script below, as described originally in 0.0.18 update PR[1], now tested live with minor fixes.

[1]: https://github.com/pop-os/repo-proprietary/pull/44#issuecomment-1150286434

```bash
#!/usr/bin/env bash

set -euo pipefail

OLD_VERSION=0.0.19
NEW_VERSION=0.0.20

pushd suites/

URL_STUB=$(grep "dl\.discordapp\.net" bionic.toml | sed -e 's/^.*"https/https/'  -e 's/".*$//')

URL_FULL=$(echo $URL_STUB | version=$NEW_VERSION envsubst)

# Download the package, to see its SHA256 hash:
echo "${URL_FULL}" | wget -i - -q

NEW_HASH=$(sha256sum discord* | sed "s/ .*//")

# Grab old SHA256:
OLD_HASH=$(grep "dl\.discordapp\.net" bionic.toml -A 1 | tail -n -1 | sed -e 's/.* = "//' -e 's/"//')

# Replace all old version numbers and hashes
sed -i "s/$OLD_VERSION/$NEW_VERSION/" *
sed -i "s/$OLD_HASH/$NEW_HASH/" *

popd
```