### PR TITLE
Update Discord to 0.0.25

### DIFF
--- a/suites/bionic.toml
+++ b/suites/bionic.toml
@@ -16,11 +16,11 @@ version = "1.60.1-1631294805"
 
 [[direct]]
 name = "discord"
-version = "0.0.24"
+version = "0.0.25"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "ba18836ccdb7a2d8e1914a096e2189317a6459c7af2c493d9a34bc81fcbca320"
+    checksum = "39809af79bcf01684ea479e8d500a4ff9deb86db2157d3ca9ac5250f2293ce77"
     arch = "amd64"
 
 [[direct]]

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -16,11 +16,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.24"
+version = "0.0.25"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "ba18836ccdb7a2d8e1914a096e2189317a6459c7af2c493d9a34bc81fcbca320"
+    checksum = "39809af79bcf01684ea479e8d500a4ff9deb86db2157d3ca9ac5250f2293ce77"
     arch = "amd64"
 
 [[direct]]

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -15,11 +15,11 @@ version = "1.60.1-1631294805"
 
 [[direct]]
 name = "discord"
-version = "0.0.24"
+version = "0.0.25"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "ba18836ccdb7a2d8e1914a096e2189317a6459c7af2c493d9a34bc81fcbca320"
+    checksum = "39809af79bcf01684ea479e8d500a4ff9deb86db2157d3ca9ac5250f2293ce77"
     arch = "amd64"
 
 [[direct]]

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.24"
+version = "0.0.25"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "ba18836ccdb7a2d8e1914a096e2189317a6459c7af2c493d9a34bc81fcbca320"
+    checksum = "39809af79bcf01684ea479e8d500a4ff9deb86db2157d3ca9ac5250f2293ce77"
     arch = "amd64"
 
 [[direct]]

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.24"
+version = "0.0.25"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "ba18836ccdb7a2d8e1914a096e2189317a6459c7af2c493d9a34bc81fcbca320"
+    checksum = "39809af79bcf01684ea479e8d500a4ff9deb86db2157d3ca9ac5250f2293ce77"
     arch = "amd64"
 
 [[direct]]


### PR DESCRIPTION
Discord currently fails to open because it's out of date.