### PR TITLE
Update Discord to 0.0.28

### DIFF
--- a/suites/bionic.toml
+++ b/suites/bionic.toml
@@ -16,11 +16,11 @@ version = "1.60.1-1631294805"
 
 [[direct]]
 name = "discord"
-version = "0.0.27"
+version = "0.0.28"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "50364b11679c5949e69c590227eb56e29f3f47c7b314bffde1e5803ea6be5cc9"
+    checksum = "4b83e1196efcd04cff137b4e294a6aab5852c54161d88dc486ade49dc8810f5c"
     arch = "amd64"
 
 [[direct]]

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -16,11 +16,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.27"
+version = "0.0.28"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "50364b11679c5949e69c590227eb56e29f3f47c7b314bffde1e5803ea6be5cc9"
+    checksum = "4b83e1196efcd04cff137b4e294a6aab5852c54161d88dc486ade49dc8810f5c"
     arch = "amd64"
 
 [[direct]]

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -15,11 +15,11 @@ version = "1.60.1-1631294805"
 
 [[direct]]
 name = "discord"
-version = "0.0.27"
+version = "0.0.28"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "50364b11679c5949e69c590227eb56e29f3f47c7b314bffde1e5803ea6be5cc9"
+    checksum = "4b83e1196efcd04cff137b4e294a6aab5852c54161d88dc486ade49dc8810f5c"
     arch = "amd64"
 
 [[direct]]

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.27"
+version = "0.0.28"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "50364b11679c5949e69c590227eb56e29f3f47c7b314bffde1e5803ea6be5cc9"
+    checksum = "4b83e1196efcd04cff137b4e294a6aab5852c54161d88dc486ade49dc8810f5c"
     arch = "amd64"
 
 [[direct]]

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.27"
+version = "0.0.28"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "50364b11679c5949e69c590227eb56e29f3f47c7b314bffde1e5803ea6be5cc9"
+    checksum = "4b83e1196efcd04cff137b4e294a6aab5852c54161d88dc486ade49dc8810f5c"
     arch = "amd64"
 
 [[direct]]


### PR DESCRIPTION
That time of year again.

Used the script I wrote the last few times:
```shell
#!/usr/bin/env bash

set -xeuo pipefail

OLD_VERSION=0.0.27
NEW_VERSION=0.0.28


cd suites/

URL_STUB=$(grep "dl\.discordapp\.net" bionic.toml | sed -e 's/^.*"https/https/'  -e 's/".*$//')


URL_FULL=$(echo $URL_STUB | version=$NEW_VERSION envsubst)

# Download the package, to see its SHA256 hash:
echo "${URL_FULL}" | wget -i - -O discord_latest.deb -q

NEW_HASH=$(sha256sum discord* | awk '{print $1}')

# Grab old SHA256:
OLD_HASH=$(grep "dl\.discordapp\.net" bionic.toml -A 1 | tail -n -1 | sed -e 's/.* = "//' -e 's/"//')

# Replace all old version numbers and hashes
sed -i "s/$OLD_VERSION/$NEW_VERSION/" *.toml
sed -i "s/$OLD_HASH/$NEW_HASH/" *.toml

# TODO: Clean up afterwards
# rm discord*

cd ../
```