### PR TITLE
Update Slack to 4.33.90

### DIFF
--- a/suites/bionic.toml
+++ b/suites/bionic.toml
@@ -25,11 +25,11 @@ version = "0.0.29"
 
 [[direct]]
 name = "slack-desktop"
-version = "4.25.0"
+version = "4.33.90"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
-    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
+    checksum = "54a73d1f85d65c900b2973e7d737a00149d3dad37d9960f9dadff097a2e854dc"
 
 [[direct]]
 name = "spotify-client"

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -25,11 +25,11 @@ version = "0.0.29"
 
 [[direct]]
 name = "slack-desktop"
-version = "4.25.0"
+version = "4.33.90"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
-    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
+    checksum = "54a73d1f85d65c900b2973e7d737a00149d3dad37d9960f9dadff097a2e854dc"
 
 [[direct]]
 name = "google-chrome-stable"

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -24,11 +24,11 @@ version = "0.0.29"
 
 [[direct]]
 name = "slack-desktop"
-version = "4.25.0"
+version = "4.33.90"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
-    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
+    checksum = "54a73d1f85d65c900b2973e7d737a00149d3dad37d9960f9dadff097a2e854dc"
 
 [[direct]]
 name = "google-chrome-stable"

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -24,11 +24,11 @@ version = "0.0.29"
 
 [[direct]]
 name = "slack-desktop"
-version = "4.25.0"
+version = "4.33.90"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
-    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
+    checksum = "54a73d1f85d65c900b2973e7d737a00149d3dad37d9960f9dadff097a2e854dc"
 
 [[direct]]
 name = "google-chrome-stable"

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -24,11 +24,11 @@ version = "0.0.29"
 
 [[direct]]
 name = "slack-desktop"
-version = "4.25.0"
+version = "4.33.90"
 
     [[direct.urls]]
     url = "https://downloads.slack-edge.com/releases/linux/${version}/prod/x64/${name}-${version}-amd64.deb"
-    checksum = "e88160a02ca489f0d54afca5bba1aeb17c886b6458eadcad73bffd959c85422c"
+    checksum = "54a73d1f85d65c900b2973e7d737a00149d3dad37d9960f9dadff097a2e854dc"
 
 [[direct]]
 name = "google-chrome-stable"


### PR DESCRIPTION
Slack currently isn't functioning. The channels still load, but there's an upgrade dialogue with no close/cancel button.

![image](https://github.com/pop-os/repo-proprietary/assets/7199422/314f8838-267e-406e-b1d4-a3449cfea3bb)