### PR TITLE
Update discord to 0.0.32

### DIFF
--- a/suites/bionic.toml
+++ b/suites/bionic.toml
@@ -16,11 +16,11 @@ version = "1.60.1-1631294805"
 
 [[direct]]
 name = "discord"
-version = "0.0.31"
+version = "0.0.32"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "7e9b986df3ae6ab22ef9a82101b8ece8247116e1486ab8caecde30e1bf0acd44"
+    checksum = "7d63e00f4bdcd3f739850713e554460cf9d162f96e3588a921105efcde2bef54"
     arch = "amd64"
 
 [[direct]]

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -16,11 +16,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.31"
+version = "0.0.32"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "7e9b986df3ae6ab22ef9a82101b8ece8247116e1486ab8caecde30e1bf0acd44"
+    checksum = "7d63e00f4bdcd3f739850713e554460cf9d162f96e3588a921105efcde2bef54"
     arch = "amd64"
 
 [[direct]]

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -15,11 +15,11 @@ version = "1.60.1-1631294805"
 
 [[direct]]
 name = "discord"
-version = "0.0.31"
+version = "0.0.32"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "7e9b986df3ae6ab22ef9a82101b8ece8247116e1486ab8caecde30e1bf0acd44"
+    checksum = "7d63e00f4bdcd3f739850713e554460cf9d162f96e3588a921105efcde2bef54"
     arch = "amd64"
 
 [[direct]]

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.31"
+version = "0.0.32"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "7e9b986df3ae6ab22ef9a82101b8ece8247116e1486ab8caecde30e1bf0acd44"
+    checksum = "7d63e00f4bdcd3f739850713e554460cf9d162f96e3588a921105efcde2bef54"
     arch = "amd64"
 
 [[direct]]

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.31"
+version = "0.0.32"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "7e9b986df3ae6ab22ef9a82101b8ece8247116e1486ab8caecde30e1bf0acd44"
+    checksum = "7d63e00f4bdcd3f739850713e554460cf9d162f96e3588a921105efcde2bef54"
     arch = "amd64"
 
 [[direct]]


### PR DESCRIPTION
As before, so again.

Per my local `discord.sh` script, latest version:

```shell
#!/usr/bin/env bash

set -xeuo pipefail

if [[ $# -lt 1 ]];
then
    echo "Usage: discord.sh OLDVERSION"
    echo "OLDVERSION number like: 31"
    exit 1
fi

OLD=$1
NEW=$((OLD + 1))

OLD_VERSION=0.0.$OLD
NEW_VERSION=0.0.$NEW


cd suites/

URL_STUB=$(grep "dl\.discordapp\.net" bionic.toml | sed -e 's/^.*"https/https/'  -e 's/".*$//')


URL_FULL=$(echo $URL_STUB | version=$NEW_VERSION envsubst)

# Download the package, to see its SHA256 hash:
echo "${URL_FULL}" | wget -i - -O discord_latest.deb -q

NEW_HASH=$(sha256sum discord* | awk '{print $1}')

# Grab old SHA256:
OLD_HASH=$(grep "dl\.discordapp\.net" bionic.toml -A 1 | tail -n -1 | sed -e 's/.* = "//' -e 's/"//')

# Replace all old version numbers and hashes
sed -i "s/$OLD_VERSION/$NEW_VERSION/" *.toml
sed -i "s/$OLD_HASH/$NEW_HASH/" *.toml

# TODO: Clean up afterwards
# rm discord*

cd ../

git add suites/
```