### PR TITLE
Update discord to 0.0.89

### DIFF
--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -16,11 +16,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.90"
+version = "0.0.89"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "a37c284a28b95486385c46580d4f250ebc51280b038808d002a547808ea031f9"
+    checksum = "e46dc8f2cd823671cfa0cd9c8de97c54febe6622265ffe823f883febe60a5d6a"
     arch = "amd64"
 
 [[direct]]

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.90"
+version = "0.0.89"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "a37c284a28b95486385c46580d4f250ebc51280b038808d002a547808ea031f9"
+    checksum = "e46dc8f2cd823671cfa0cd9c8de97c54febe6622265ffe823f883febe60a5d6a"
     arch = "amd64"
 
 [[direct]]

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.90"
+version = "0.0.89"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "a37c284a28b95486385c46580d4f250ebc51280b038808d002a547808ea031f9"
+    checksum = "e46dc8f2cd823671cfa0cd9c8de97c54febe6622265ffe823f883febe60a5d6a"
     arch = "amd64"
 
 [[direct]]

--- a/suites/noble.toml
+++ b/suites/noble.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.90"
+version = "0.0.89"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "a37c284a28b95486385c46580d4f250ebc51280b038808d002a547808ea031f9"
+    checksum = "e46dc8f2cd823671cfa0cd9c8de97c54febe6622265ffe823f883febe60a5d6a"
     arch = "amd64"
 
 [[direct]]


### PR DESCRIPTION
Weird one today. Discord seems to have been downgraded to `0.0.89` after 2 weeks.