### PR TITLE
fix (CI): Correct Discord static URL

### DIFF
--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -20,7 +20,7 @@ version = "0.0.90-1"
 
     [[direct.urls]]
 #    url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    url = "https://dl.discordapp.net/apps/linux/${version}/discord-0.0.89.deb"
+    url = "https://dl.discordapp.net/apps/linux/0.0.89/discord-0.0.89.deb"
     checksum = "e46dc8f2cd823671cfa0cd9c8de97c54febe6622265ffe823f883febe60a5d6a"
     arch = "amd64"
 

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -19,7 +19,7 @@ version = "0.0.90-1"
 
     [[direct.urls]]
 #    url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    url = "https://dl.discordapp.net/apps/linux/${version}/discord-0.0.89.deb"
+    url = "https://dl.discordapp.net/apps/linux/0.0.89/discord-0.0.89.deb"
     checksum = "e46dc8f2cd823671cfa0cd9c8de97c54febe6622265ffe823f883febe60a5d6a"
     arch = "amd64"
 

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -19,7 +19,7 @@ version = "0.0.90-1"
 
     [[direct.urls]]
 #    url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    url = "https://dl.discordapp.net/apps/linux/${version}/discord-0.0.89.deb"
+    url = "https://dl.discordapp.net/apps/linux/0.0.89/discord-0.0.89.deb"
     checksum = "e46dc8f2cd823671cfa0cd9c8de97c54febe6622265ffe823f883febe60a5d6a"
     arch = "amd64"
 

--- a/suites/noble.toml
+++ b/suites/noble.toml
@@ -19,7 +19,7 @@ version = "0.0.90-1"
 
     [[direct.urls]]
 #    url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    url = "https://dl.discordapp.net/apps/linux/${version}/discord-0.0.89.deb"
+    url = "https://dl.discordapp.net/apps/linux/0.0.89/discord-0.0.89.deb"
     checksum = "e46dc8f2cd823671cfa0cd9c8de97c54febe6622265ffe823f883febe60a5d6a"
     arch = "amd64"
 


### PR DESCRIPTION
Fixes https://github.com/pop-os/repo-proprietary/pull/127.
See https://github.com/pop-os/repo-proprietary/pull/126 for downgrade background.