### PR TITLE
Update discord to 0.0.93

### DIFF
--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -16,11 +16,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.92"
+version = "0.0.93"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "821a355e915d2038868a2b931b1e690bad9b80b727e4ab4e7c9eac76ff95d809"
+    checksum = "1a9bb887e1001eef24bb23c1482193ae2f31c271bc697b21157f90968657328f"
     arch = "amd64"
 
 [[direct]]

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.92"
+version = "0.0.93"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "821a355e915d2038868a2b931b1e690bad9b80b727e4ab4e7c9eac76ff95d809"
+    checksum = "1a9bb887e1001eef24bb23c1482193ae2f31c271bc697b21157f90968657328f"
     arch = "amd64"
 
 [[direct]]

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.92"
+version = "0.0.93"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "821a355e915d2038868a2b931b1e690bad9b80b727e4ab4e7c9eac76ff95d809"
+    checksum = "1a9bb887e1001eef24bb23c1482193ae2f31c271bc697b21157f90968657328f"
     arch = "amd64"
 
 [[direct]]

--- a/suites/noble.toml
+++ b/suites/noble.toml
@@ -15,11 +15,11 @@ version = "1.67.2-1652812855"
 
 [[direct]]
 name = "discord"
-version = "0.0.92"
+version = "0.0.93"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "821a355e915d2038868a2b931b1e690bad9b80b727e4ab4e7c9eac76ff95d809"
+    checksum = "1a9bb887e1001eef24bb23c1482193ae2f31c271bc697b21157f90968657328f"
     arch = "amd64"
 
 [[direct]]


### PR DESCRIPTION
I know the CI might still be broken, but I think we should still keep this up to date to be ready as soon as the CI is fixed.