### PR TITLE
Update discord to 1.0.136

### DIFF
--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -16,11 +16,11 @@ version = "1.100.0-1746623151"
 
 [[direct]]
 name = "discord"
-version = "0.0.135"
+version = "1.0.136"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "802c0121bba21e8088f9e63f178beebd9ee9f8d9b561ecbcdacbfec990b66606"
+    checksum = "b5cf66221b46f3f744ea571fbf774def8425e791a491f3b01874305e2d307715"
     arch = "amd64"
 
 [[direct]]

--- a/suites/impish.toml
+++ b/suites/impish.toml
@@ -15,11 +15,11 @@ version = "1.100.0-1746623151"
 
 [[direct]]
 name = "discord"
-version = "0.0.135"
+version = "1.0.136"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "802c0121bba21e8088f9e63f178beebd9ee9f8d9b561ecbcdacbfec990b66606"
+    checksum = "b5cf66221b46f3f744ea571fbf774def8425e791a491f3b01874305e2d307715"
     arch = "amd64"
 
 [[direct]]

--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -15,11 +15,11 @@ version = "1.100.0-1746623151"
 
 [[direct]]
 name = "discord"
-version = "0.0.135"
+version = "1.0.136"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "802c0121bba21e8088f9e63f178beebd9ee9f8d9b561ecbcdacbfec990b66606"
+    checksum = "b5cf66221b46f3f744ea571fbf774def8425e791a491f3b01874305e2d307715"
     arch = "amd64"
 
 [[direct]]

--- a/suites/noble.toml
+++ b/suites/noble.toml
@@ -15,11 +15,11 @@ version = "1.100.0-1746623151"
 
 [[direct]]
 name = "discord"
-version = "0.0.135"
+version = "1.0.136"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "802c0121bba21e8088f9e63f178beebd9ee9f8d9b561ecbcdacbfec990b66606"
+    checksum = "b5cf66221b46f3f744ea571fbf774def8425e791a491f3b01874305e2d307715"
     arch = "amd64"
 
 [[direct]]

--- a/suites/resolute.toml
+++ b/suites/resolute.toml
@@ -15,11 +15,11 @@ version = "1.100.0-1746623151"
 
 [[direct]]
 name = "discord"
-version = "0.0.132"
+version = "1.0.136"
 
     [[direct.urls]]
     url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.deb"
-    checksum = "a55594e13ec357ed4dc093024706b3fd794b50ed4737b9c331c2810bb66958ae"
+    checksum = "b5cf66221b46f3f744ea571fbf774def8425e791a491f3b01874305e2d307715"
     arch = "amd64"
 
 [[direct]]


### PR DESCRIPTION
> [!WARNING]
> Seems discord bumped from 0.0.x to 1.0.x schema, updated here.
